### PR TITLE
Fix task id counter restore issue

### DIFF
--- a/lib/widgets/task_list.dart
+++ b/lib/widgets/task_list.dart
@@ -42,7 +42,7 @@ class Task {
 
   // Create Task from Map
   factory Task.fromJson(Map<String, dynamic> json) {
-    return Task(
+    final task = Task(
       title: json['title'],
       description: json['description'],
       id: json['id'],
@@ -51,6 +51,13 @@ class Task {
       dueDate: json['dueDate'] != null ? DateTime.parse(json['dueDate']) : null,
       photoPath: json['photoPath'],
     );
+
+    // Ensure the next generated id is greater than any restored id.
+    if (task.id >= _idCounter) {
+      _idCounter = task.id + 1;
+    }
+
+    return task;
   }
 }
 

--- a/test/task_test.dart
+++ b/test/task_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_intro/widgets/task_list.dart';
+
+void main() {
+  test('Task.fromJson updates id counter', () {
+    final map = {
+      'title': 'existing',
+      'description': '',
+      'id': 5,
+      'isCompleted': false,
+      'created': DateTime.now().toIso8601String(),
+      'dueDate': null,
+      'photoPath': null,
+    };
+
+    final restored = Task.fromJson(map);
+    final newTask = Task(title: 'new');
+
+    expect(newTask.id, restored.id + 1);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure loaded tasks update the static id counter so new task IDs do not clash
- add a regression test for ID restoration logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4adce2508321b907ca9ff10f7109